### PR TITLE
update workflow java versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-        version: [ 15.0.1.hs-adpt, 15.0.1.j9-adpt, 15.0.1-amzn, 15.0.1-zulu, 15.0.1.fx-zulu, 15.0.1.fx-librca, 15.0.1-librca, 15.0.1-open, 15.0.1-sapmchn ]
+        version: [15.0.1-amzn, 15.0.1-zulu, 15.0.1.fx-zulu, 15.0.1.fx-librca, 15.0.1-librca, 15.0.1-open, 15.0.1-sapmchn, 15.0.1-tem ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-        version: [15.0.1-amzn, 15.0.1-zulu, 15.0.1.fx-zulu, 15.0.1.fx-librca, 15.0.1-librca, 15.0.1-open, 15.0.1-sapmchn, 15.0.1-tem ]
+        version: [19.0.1-amzn, 19.0.1-zulu, 19.0.1.fx-zulu, 19.0.1.fx-librca, 19.0.1-librca, 19.0.1-open, 19.0.1-sapmchn, 19.0.1-tem ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-        version: [19.0.1-amzn, 19.0.1-zulu, 19.0.1.fx-zulu, 19.0.1.fx-librca, 19.0.1-librca, 19.0.1-open, 19.0.1-sapmchn, 19.0.1-tem ]
+        version: [ 19.0.1-amzn, 19.0.1-librca, 19.0.1-open, 19.0.1-sapmchn, 19.0.1-tem, 19.0.1-zulu, 19.0.1.fx-librca, 19.0.1.fx-zulu ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout


### PR DESCRIPTION
In order to fix main workflow I did the following 

- AdoptOpenJDK is now Eclipse Temurin
- bump java version to 19.0.1
- sort flavors
